### PR TITLE
Start SMEE client if WEBPROXY_URL is set

### DIFF
--- a/zeroae/goblet/utils.py
+++ b/zeroae/goblet/utils.py
@@ -62,3 +62,15 @@ def get_create_app_url():
     host = config.GHE_HOST
 
     return f"{proto}://{host}{org_path}/settings/apps/new"
+
+
+def start_smee_client(target_url) -> str:
+    """Start a Threaded Smee Client with source set to WEBHOOK_PROXY_URL"""
+    from threading import Thread
+    from zeroae.smee import SmeeClient
+
+    client = SmeeClient(source=config.WEBHOOK_PROXY_URL, target=target_url)
+    t = Thread(name=client.source, target=client.run, daemon=True)
+    t.start()
+
+    return client.source


### PR DESCRIPTION
Start smee-client if the WEBHOOK_PROXY environment variable is set

ref: #8