### PR TITLE
Add example app

### DIFF
--- a/examples/chalice/.chalice/config.json
+++ b/examples/chalice/.chalice/config.json
@@ -1,0 +1,9 @@
+{
+  "version": "2.0",
+  "app_name": "chalice",
+  "stages": {
+    "dev": {
+      "api_gateway_stage": "api"
+    }
+  }
+}

--- a/examples/chalice/.gitignore
+++ b/examples/chalice/.gitignore
@@ -1,0 +1,2 @@
+.chalice/deployments/
+.chalice/venv/

--- a/examples/chalice/app.py
+++ b/examples/chalice/app.py
@@ -1,0 +1,21 @@
+import json
+
+from chalice import Chalice
+from environs import Env
+
+from zeroae.goblet import chalice as goblet
+
+# Load Configuration Options
+env: Env = Env()
+env.read_env()
+goblet.configure(env)
+
+# Register the Application
+app = Chalice(app_name="chalice")
+app.experimental_feature_flags.update(["BLUEPRINTS"])
+app.register_blueprint(goblet.bp, name_prefix="gh")
+
+
+@goblet.bp.on_gh_event("ping")
+def ping(payload):
+    app.log.info(json.dumps(payload))

--- a/examples/chalice/requirements.txt
+++ b/examples/chalice/requirements.txt
@@ -1,0 +1,1 @@
+zeroae-goblet

--- a/zeroae/goblet/config.py
+++ b/zeroae/goblet/config.py
@@ -99,7 +99,7 @@ def _load_app_options(env: Env):
         APP_PUBLIC = env.bool("PUBLIC", True)
         with env.prefixed("DEFAULT_"):
             APP_DEFAULT_EVENTS = env.list(
-                "EVENTS", "push", validate=ContainsOnly(valid_events)
+                "EVENTS", "public", validate=ContainsOnly(valid_events)
             )
             APP_DEFAULT_PERMISSIONS = env.dict("PERMISSIONS", "metadata=read")
 


### PR DESCRIPTION
The goal of this PR is to add an example usage app for zeroae-goblet

Assuming you have checked out zeroae-goblet and `pip installed -e` here is what comes next

In terminal 1,  start the Smee client `smee -l DEBUG -P /events` and click on the Smee link to see the events that GitHub is sending.
    
In terminal 2:
    
    # Start the chalice app
    export WEBHOOK_PROXY_URL=<from terminal 1>
    chalice --local 
    
    